### PR TITLE
[FIX] hr_holidays_legal_leave: error on creating new employee

### DIFF
--- a/hr_holidays_legal_leave/models/hr_employee.py
+++ b/hr_holidays_legal_leave/models/hr_employee.py
@@ -2,8 +2,8 @@
 # ©  2015 iDT LABS (http://www.@idtlabs.sl)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openerp import models, api, fields, _
-from openerp.exceptions import Warning as UserError
+from odoo import models, api, fields, _
+from odoo.exceptions import UserError
 
 
 class HrEmployee(models.Model):
@@ -29,12 +29,12 @@ class HrEmployee(models.Model):
                     'number_of_days_temp': diff
                 }
             )
+            leave.action_approve()
+            if leave.double_validation:
+                leave.action_validate()
         elif diff < 0:
             raise UserError(_('You cannot reduce validated allocation '
                               'requests.'))
-
-        for sig in ('confirm', 'validate', 'second_validate'):
-            leave.signal_workflow(sig)
 
     @api.multi
     def _compute_remaining_days(self):

--- a/hr_holidays_legal_leave/tests/test_holidays_legal_leave.py
+++ b/hr_holidays_legal_leave/tests/test_holidays_legal_leave.py
@@ -52,3 +52,10 @@ class TestHolidaysLegalLeave(common.TransactionCase):
         # let's attempt setting remaining leave
         self.employee.write({'remaining_leaves': 20})
         self.assertEqual(self.employee.remaining_leaves, 20)
+
+    def test_create_employee(self):
+        '''Check that we are able to create new employee and that _inverse_remaining_days doesn't raise error'''
+        self.employee_model.create({
+            'name': 'Employee 1',
+            'remaining_leaves': 0,
+        })


### PR DESCRIPTION
  File "/mnt/files/git/oca_hr-10/hr_holidays_legal_leave/models/hr_employee.py", line 41, in _inverse_remaining_days
    leave.signal_workflow(sig)
UnboundLocalError: local variable 'leave' referenced before assignment
